### PR TITLE
[fix] 在注册事件之前调用初始化

### DIFF
--- a/UnityProject/Assets/GameScripts/HotFix/GameLogic/Event/EventInterfaceHelper.cs
+++ b/UnityProject/Assets/GameScripts/HotFix/GameLogic/Event/EventInterfaceHelper.cs
@@ -13,6 +13,7 @@ namespace GameLogic
         /// </summary>
         public static void Init()
         {
+            GameEvent.EventMgr.Init();
             RegisterEventInterface_Logic.Register(GameEvent.EventMgr);
             RegisterEventInterface_UI.Register(GameEvent.EventMgr);
         }

--- a/UnityProject/Assets/GameScripts/HotFix/GameLogic/Event/RegisterEventInterface_Logic.cs
+++ b/UnityProject/Assets/GameScripts/HotFix/GameLogic/Event/RegisterEventInterface_Logic.cs
@@ -34,7 +34,6 @@ namespace GameLogic
 
                 object obj = Activator.CreateInstance(type, mgr.Dispatcher);
 
-                mgr.Init();
                 mgr.RegWrapInterface(obj.GetType().GetInterfaces()[0]?.FullName, obj);
             }
         }


### PR DESCRIPTION
由于有多个事件的接口，foreach 每次都会 Init -> clear字典，挪到注册之前 Init。shutdow 时也会 clear