### PR TITLE
加载热更新程序集的崩溃bug修正

### DIFF
--- a/UnityProject/Assets/GameScripts/HotFix/GameLogic/GameApp_RegisterSystem.cs
+++ b/UnityProject/Assets/GameScripts/HotFix/GameLogic/GameApp_RegisterSystem.cs
@@ -3,10 +3,10 @@ using GameLogic;
 using TEngine;
 using UnityEngine;
 
-public partial class GameApp
+public partial class GameApp : Singleton<GameApp>
 {
     private List<ILogicSys> _listLogicMgr;
-    
+
     public override void Active()
     {
         CodeTypes.Instance.Init(_hotfixAssembly.ToArray());
@@ -15,13 +15,13 @@ public partial class GameApp
         RegisterAllSystem();
         InitSystemSetting();
     }
-    
+
     /// <summary>
     /// 设置一些通用的系统属性。
     /// </summary>
     private void InitSystemSetting()
     {
-        
+
     }
 
     /// <summary>
@@ -32,7 +32,7 @@ public partial class GameApp
         //带生命周期的单例系统。
         AddLogicSys(BehaviourSingleSystem.Instance);
     }
-    
+
     /// <summary>
     /// 注册逻辑系统。
     /// </summary>


### PR DESCRIPTION
之前所用的GameModule.Resource.LoadAsset虽然是同步接口，但是是异步通过回调返回结果，这有一个致命问题，加载时的顺序无法保证得到回调的顺序，以至于会出现加载程序集有依赖的情况下无法通过程序集设定好的顺序进行加载，从而导致应用崩溃。现改为等待加载回调结果再进行后续的程序集加载