### PR TITLE
AssetsReference的自动销毁计数处理完善，兼容unity Instantiate和不可见对象

### DIFF
--- a/UnityProject/Assets/TEngine/Runtime/Module/ResourceModule/Reference/AssetsReference.cs
+++ b/UnityProject/Assets/TEngine/Runtime/Module/ResourceModule/Reference/AssetsReference.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.Serialization;
 using Object = UnityEngine.Object;
 
 namespace TEngine
@@ -30,6 +29,9 @@ namespace TEngine
         private List<AssetsRefInfo> refAssetInfoList;
 
         private static IResourceModule _resourceModule;
+
+        private static Dictionary<GameObject, AssetsReference> _originalRefs = new();
+
 
         private void CheckInit()
         {
@@ -60,9 +62,15 @@ namespace TEngine
             }
         }
 
+
         private void Awake()
         {
-            sourceGameObject = null;
+            // If it is a clone, clear the reference records before cloning
+            if (!_originalRefs.ContainsKey(gameObject) || _originalRefs[gameObject] != this)
+            {
+                sourceGameObject = null;
+                refAssetInfoList?.Clear();
+            }
         }
 
         private void OnDestroy()
@@ -103,10 +111,16 @@ namespace TEngine
 
             _resourceModule = resourceModule;
             sourceGameObject = source;
+
+            if (!_originalRefs.ContainsKey(gameObject))
+            {
+                _originalRefs.Add(gameObject, this);
+            }
+
             return this;
         }
 
-        public AssetsReference Ref<T>(T source, IResourceModule resourceModule = null) where T : UnityEngine.Object
+        public AssetsReference Ref<T>(T source, IResourceModule resourceModule = null) where T : Object
         {
             if (source == null)
             {
@@ -155,7 +169,7 @@ namespace TEngine
             return comp ? comp.Ref(source, resourceModule) : instance.AddComponent<AssetsReference>().Ref(source, resourceModule);
         }
 
-        public static AssetsReference Ref<T>(T source, GameObject instance, IResourceModule resourceModule = null) where T : UnityEngine.Object
+        public static AssetsReference Ref<T>(T source, GameObject instance, IResourceModule resourceModule = null) where T : Object
         {
             if (source == null)
             {


### PR DESCRIPTION
#157 你修复这个问题时，在Awake方法中直接设置sourceGameObject = null; 应该是想把克隆后的对象的源引用置空，就不会出现多次销毁。
但是这里你没有考虑生命周期的问题，当GameObject的父节点不可见时，Awake并不会在Object.Instantiate后立即执行，此时会先执行Ref(source, resourceModule)设置，然后等GameObject后面可见时，Awake执行，导致sourceGameObject被错误的置空，又会造成内存泄漏。