### PR TITLE
修复一下图集打包工具的一些问题

### DIFF
--- a/UnityProject/Assets/TEngine/Editor/AtlasMakerEditor/SpritePostprocessor.cs
+++ b/UnityProject/Assets/TEngine/Editor/AtlasMakerEditor/SpritePostprocessor.cs
@@ -81,14 +81,14 @@ namespace TEngine.Editor
                 {
                     EditorSpriteSaveInfo.OnDeleteSprite(oldPaths[i]);
                     LogProcessed("[Moved From]", oldPaths[i]);
-                    EditorSpriteSaveInfo.MarkParentAtlasesDirty(oldPaths[i]);
+                    EditorSpriteSaveInfo.MarkParentAtlasesDirty(oldPaths[i], true);
                 }
 
                 if (ShouldProcessAsset(newPaths[i]))
                 {
                     EditorSpriteSaveInfo.OnImportSprite(newPaths[i]);
                     LogProcessed("[Moved To]", newPaths[i]);
-                    EditorSpriteSaveInfo.MarkParentAtlasesDirty(newPaths[i]);
+                    EditorSpriteSaveInfo.MarkParentAtlasesDirty(newPaths[i], false);
                 }
             }
         }


### PR DESCRIPTION
1、v2模式移除资源的话会存在空引用在图集里
2、切换两种模式，不会删除另一种模式的图集
3、非v2模式，如果项目内非图集路径资源移动，不会及时更新图集
4、非v2模式，项目内非图集路径资源移动，移除图集新增资源，移入反而是图集减少资源
修改后，导入资源的图集不进行删除原图集，删除资源的图集会进行删除原图集，重新打包图集保证资源引用的干净，强制生成图集则会把所有图集都删除，重新生成一遍