### PR TITLE
事件管理问题修复

### DIFF
--- a/UnityProject/Assets/TEngine/Runtime/Core/GameEvent/EventDelegateData.cs
+++ b/UnityProject/Assets/TEngine/Runtime/Core/GameEvent/EventDelegateData.cs
@@ -91,6 +91,7 @@ namespace TEngine
                 }
 
                 _deleteList.Clear();
+                _dirty = false;
             }
         }
 

--- a/UnityProject/Assets/TEngine/Runtime/Core/GameEvent/EventDispatcher.cs
+++ b/UnityProject/Assets/TEngine/Runtime/Core/GameEvent/EventDispatcher.cs
@@ -11,7 +11,7 @@ namespace TEngine
         /// <summary>
         /// 事件Table。
         /// </summary>
-        private static readonly Dictionary<int, EventDelegateData> _eventTable = new Dictionary<int, EventDelegateData>();
+        private readonly Dictionary<int, EventDelegateData> _eventTable = new Dictionary<int, EventDelegateData>();
 
         /// <summary>
         /// 清空事件表。


### PR DESCRIPTION
1. _dirty还原

> 检测脏数据之后，_dirty并未还原

2. EventDispatcher._eventTable不应该是静态的

> 如果多次实例化EventMgr，会导致一个EventMgr Send时，还会触发其他所有EventMgr实例