### PR TITLE
修复 RawFile 同步加载句柄入池强转崩溃

### DIFF
--- a/UnityProject/Assets/TEngine/Runtime/Module/ResourceModule/ResourceModule.AssetObject.cs
+++ b/UnityProject/Assets/TEngine/Runtime/Module/ResourceModule/ResourceModule.AssetObject.cs
@@ -10,7 +10,7 @@ namespace TEngine
         /// </summary>
         private sealed class AssetObject : ObjectBase
         {
-            private AssetHandle _assetHandle = null;
+            private HandleBase _assetHandle = null;
             private ResourceModule _resourceModule;
 
             public static AssetObject Create(string name, object target, object assetHandle, ResourceModule resourceModule)
@@ -27,7 +27,11 @@ namespace TEngine
 
                 AssetObject assetObject = MemoryPool.Acquire<AssetObject>();
                 assetObject.Initialize(name, target);
-                assetObject._assetHandle = (AssetHandle)assetHandle;
+                if (assetHandle is not HandleBase handleBase)
+                {
+                    throw new GameFrameworkException($"Unsupported handle type: {assetHandle.GetType()}.");
+                }
+                assetObject._assetHandle = handleBase;
                 assetObject._resourceModule = resourceModule;
                 return assetObject;
             }
@@ -47,7 +51,7 @@ namespace TEngine
             {
                 if (!isShutdown)
                 {
-                    AssetHandle handle = _assetHandle;
+                    HandleBase handle = _assetHandle;
                     if (handle is { IsValid: true })
                     {
                         handle.Dispose();


### PR DESCRIPTION
## 问题
AssetObject._assetHandle 声明为 AssetHandle，但 LoadRawFileSync 入池传入的是
RawFileHandle（与 AssetHandle 同为 HandleBase 平级子类，无继承关系），
(AssetHandle) 强转抛 InvalidCastException，同步读取 RawFile 必崩。

## 修复
字段及局部变量类型 AssetHandle → HandleBase（池回收只用 Dispose/IsValid，
皆基类成员；AssetHandle 为子类，既有路径不变）。Create 硬转改为
is not HandleBase 校验 + 明确异常，加固弱类型入口。

## 验证
LoadRawFileSync 首次加载+二次缓存命中均正常；