### PR TITLE
共2个提交内容，1个多语言加载时的bug修复，1个针对UNITY2022的小优化

### DIFF
--- a/UnityProject/Assets/TEngine/Runtime/Core/Utility/Utility.Http.cs
+++ b/UnityProject/Assets/TEngine/Runtime/Core/Utility/Utility.Http.cs
@@ -43,7 +43,7 @@ namespace TEngine
                 var cts = new CancellationTokenSource();
                 cts.CancelAfterSlim(TimeSpan.FromSeconds(timeout));
 
-#if UNITY_6000_0_OR_NEWER
+#if UNITY_2022_3_OR_NEWER
                 using UnityWebRequest unityWebRequest = UnityWebRequest.PostWwwForm(url, postData);
 #else
                 using UnityWebRequest unityWebRequest = UnityWebRequest.Post(url, postData);

--- a/UnityProject/Assets/TEngine/Runtime/Module/DebugerModule/Component/DebuggerModule.QualityInformationWindow.cs
+++ b/UnityProject/Assets/TEngine/Runtime/Module/DebugerModule/Component/DebuggerModule.QualityInformationWindow.cs
@@ -33,7 +33,7 @@ namespace TEngine
                     DrawItem("Desired Color Space", QualitySettings.desiredColorSpace.ToString());
                     DrawItem("Max Queued Frames", QualitySettings.maxQueuedFrames.ToString());
                     DrawItem("Pixel Light Count", QualitySettings.pixelLightCount.ToString());
-#if UNITY_6000_0_OR_NEWER
+#if UNITY_2022_3_OR_NEWER
                     DrawItem("Master Texture Limit", QualitySettings.globalTextureMipmapLimit.ToString());
 #else
                     DrawItem("Master Texture Limit", QualitySettings.masterTextureLimit.ToString());

--- a/UnityProject/Assets/TEngine/Runtime/Module/DebugerModule/Component/DebuggerModule.ScreenInformationWindow.cs
+++ b/UnityProject/Assets/TEngine/Runtime/Module/DebugerModule/Component/DebuggerModule.ScreenInformationWindow.cs
@@ -58,7 +58,7 @@ namespace TEngine
 
             private string GetResolutionString(Resolution resolution)
             {
-#if UNITY_6000_0_OR_NEWER
+#if UNITY_2022_3_OR_NEWER
                 return Utility.Text.Format("{0} x {1} @ {2}Hz", resolution.width, resolution.height, resolution.refreshRateRatio);
 #else
                 return Utility.Text.Format("{0} x {1} @ {2}Hz", resolution.width, resolution.height, resolution.refreshRate);

--- a/UnityProject/Assets/TEngine/Runtime/Module/LocalizationModule/Core/LocalizationReader.cs
+++ b/UnityProject/Assets/TEngine/Runtime/Module/LocalizationModule/Core/LocalizationReader.cs
@@ -102,6 +102,10 @@ namespace TEngine.Localization
 
 		public static List<string[]> ReadCSV( string Text, char Separator=',' )
 		{
+			// The text content imported from the text will support \r\n break text, and no need to replace \r\n to empty string any more.
+			Text = Text.Replace("\r\n", "\n");
+			Text = Text.Replace("\r", "\n");
+
 			int iStart = 0;
 			List<string[]> CSV = new List<string[]>();
 


### PR DESCRIPTION
- 错误修改
a23406a3	让导入的多语言配置文件支持使用\r\n，原本只支持\n，当出现\r\n时，多语言的key里会带上\r，导致无法匹配

- 优化
ecc00e61	修复几处在Unity2022中已经被标记为过时了的API，避免每次使用2022打开时提示自动升级修复和Warning的问题	
